### PR TITLE
Cope with missing User-Agent header

### DIFF
--- a/ismobile/middleware.py
+++ b/ismobile/middleware.py
@@ -5,6 +5,6 @@ class MobileControlMiddleware(object):
         self.get_response = get_response
 
     def __call__(self, request):
-        request.IS_MOBILE = get_is_mobil(request.META['HTTP_USER_AGENT'])
+        request.IS_MOBILE = get_is_mobil(request.META.get('HTTP_USER_AGENT'))
         response = self.get_response(request)
         return response

--- a/ismobile/utils.py
+++ b/ismobile/utils.py
@@ -1,5 +1,10 @@
 import re
 
 def get_is_mobil(http_user_agent):
+    if http_user_agent is None:
+        # Default to assuming desktop if no user-agent header is
+        # present.
+        return False
+
     is_mobile_re=re.compile(r".*(iphone|mobile|androidtouch)",re.IGNORECASE)
     return is_mobile_re.match(http_user_agent) != None


### PR DESCRIPTION
The User-Agent header is missing in most test scenarios. It's also possible for it to be missing in real web traffic.